### PR TITLE
feat: cardano-cli 11.0.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM ghcr.io/blinklabs-io/haskell:9.6.7-3.12.1.0-1 AS cardano-cli-build
+FROM ghcr.io/blinklabs-io/haskell:9.6.7-3.12.1.0-3 AS cardano-cli-build
 # Install cardano-cli
-ARG CLI_VERSION=10.15.1.0
+ARG CLI_VERSION=11.0.0.0
 ENV CLI_VERSION=${CLI_VERSION}
 RUN echo "Building tags/${CLI_VERSION}..." \
     && echo tags/cardano-cli-${CLI_VERSION} > /CARDANO_BRANCH \
@@ -37,9 +37,11 @@ RUN apt-get update -y && \
     liblmdb0 \
     libncursesw5 \
     libnuma1 \
+    libsnappy1v5 \
     libsystemd0 \
     libssl3 \
     libtinfo6 \
+    liburing2 \
     llvm-14-runtime \
     netbase \
     pkg-config \


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `cardano-cli` to 11.0.0.0 and update the Haskell base image to ensure compatibility. Adds required runtime libraries to prevent missing-dependency errors.

- **Dependencies**
  - Bump `cardano-cli` to `11.0.0.0`.
  - Update base image to `ghcr.io/blinklabs-io/haskell:9.6.7-3.12.1.0-3`.
  - Add `libsnappy1v5` and `liburing2` to runtime packages.

<sup>Written for commit f128b279bc4003b19324b1d5d8faba8f1c10ff94. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Cardano CLI to version 11.0.0.0
  * Updated base Docker image to latest version
  * Added system library dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->